### PR TITLE
SALTO-2658 - Handle salto fetch without current environment

### DIFF
--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -307,7 +307,12 @@ const loadLocalWorkspaceImpl = async ({
       const allEnvSourcesEmpty = envSources.length === 1 && await envSources[0].naclFiles.isEmpty()
       if (allEnvSourcesEmpty) {
         const commonSource = elemSources.sources[elemSources.commonSourceName].naclFiles
-        const { currentEnv } = (await workspaceConfig.getWorkspaceConfig())
+        let { currentEnv } = (await workspaceConfig.getWorkspaceConfig())
+        // Probably workspaceConfig wasn't initialized yet, so we set current env to a default one
+        if (!currentEnv) {
+          currentEnv = ws.currentEnv() || ws.envs()[0]
+          await ws.setCurrentEnv(currentEnv)
+        }
         return commonSource.rename(getLocalEnvName(currentEnv))
       }
       return ws.demoteAll()

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -310,7 +310,7 @@ const loadLocalWorkspaceImpl = async ({
         let { currentEnv } = (await workspaceConfig.getWorkspaceConfig())
         // Probably workspaceConfig wasn't initialized yet, so we set current env to a default one
         if (!currentEnv) {
-          currentEnv = ws.currentEnv() || ws.envs()[0]
+          currentEnv = ws.currentEnv()
           await ws.setCurrentEnv(currentEnv)
         }
         return commonSource.rename(getLocalEnvName(currentEnv))

--- a/packages/core/test/workspace/local/workspace.test.ts
+++ b/packages/core/test/workspace/local/workspace.test.ts
@@ -304,9 +304,37 @@ describe('local workspace', () => {
         elemSource: EnvironmentsSources
       ) => {
         wsElemSrcs = elemSource
+        let currentEnv = 'default'
         return {
           demoteAll: jest.fn(),
+          setCurrentEnv: async () => { currentEnv = 'wasSet' },
+          currentEnv: () => currentEnv,
         }
+      })
+    })
+
+    describe('without any current env', () => {
+      beforeAll(() => {
+        const getConf = repoDirStore.get as jest.Mock
+        getConf.mockResolvedValue({ buffer: `
+        salto {
+          uid = "98bb902f-a144-42da-9672-f36e312e8e09"
+          name = "test"
+          envs = [
+              {
+                name = "default"
+              }
+          ]
+        }
+        `,
+        filename: '' })
+      })
+
+      it('should not crash and should set env', async () => {
+        const workspace = await loadLocalWorkspace({ path: '/west' })
+        await awu(Object.values(wsElemSrcs.sources)).forEach(src => src.naclFiles.load({}))
+        await workspace.demoteAll()
+        expect(workspace.currentEnv()).toBe('wasSet')
       })
     })
 


### PR DESCRIPTION
On salto fetch without current enviroment, set the current enviroment

---

Usually happens on fetch attempt when workspace.nacl doesn't exists

---
_Release Notes_: 
Salto fetch won't crash if workspace.nacl wasn't initialized or the current enviroment wasn't set
